### PR TITLE
Add functions for `get_workflow_runs` task

### DIFF
--- a/tasks/get_workflow_runs.py
+++ b/tasks/get_workflow_runs.py
@@ -1,0 +1,107 @@
+import functools
+import os
+import time
+
+import requests
+
+from . import DATA_DIR
+
+
+REPOS_URL = "https://api.github.com/orgs/opensafely/repos"
+WORKFLOW_RUNS_URL_TEMPLATE = (
+    "https://api.github.com/repos/opensafely/{repo}/actions/runs"
+)
+
+
+def write_json(data, filepath):  # pragma: no cover
+    # Placeholder: We will eventually import a `write_json` from `io`.
+    print(f"Writing a {type(data).__name__} of {len(data)} items to {filepath}")
+
+
+class GitHubAPISession(requests.Session):
+    def __init__(self, token=None):
+        super().__init__()
+        if token := os.environ.get("GITHUB_WORKFLOW_RUNS_TOKEN"):
+            self.headers.update({"Authorization": f"Bearer {token}"})
+
+
+def retry(log, max_retries=3, backoff_seconds=0.5):
+    def decorator(get):
+        @functools.wraps(get)
+        def wrapper(url, **kwargs):
+            retry_count = 0
+            while True:
+                try:
+                    response = get(url, **kwargs)
+                    response.raise_for_status()
+                    return response
+                except requests.RequestException as error:
+                    if retry_count < max_retries:
+                        seconds = backoff_seconds * (2**retry_count)
+                        log(
+                            f"Error fetching {url}: {error}\n"
+                            f"Retrying in {seconds} seconds (retry attempt {retry_count + 1}) ..."
+                        )
+                        time.sleep(seconds)
+                        retry_count += 1
+
+                    else:
+                        log(
+                            f"Error fetching {url}: {error}\n"
+                            f"Skipping as maximum retries reached ({max_retries})."
+                        )
+                        return False
+
+        return wrapper
+
+    return decorator
+
+
+def get_all_pages_with_retry(get_function, first_url, **kwargs):
+    url = first_url
+    while True:
+        response = retry(print)(get_function)(url, **kwargs)
+        if not response:  # response is False on failure due to `retry`
+            break
+        yield response
+        if next_link := response.links.get("next"):
+            url = next_link["url"]
+        else:
+            break
+
+
+def get_repo_names(session):
+    query_time = int(time.time())
+    output_dir = DATA_DIR / "workflow_runs" / "repos" / str(query_time)
+
+    for page_number, response in enumerate(
+        get_all_pages_with_retry(
+            session.get, REPOS_URL, params={"format": "json", "per_page": 100}
+        ),
+        start=1,
+    ):
+        page = response.json()
+        write_json(
+            page,
+            output_dir / "pages" / f"page_{page_number}.json",
+        )
+        yield from (repo["name"] for repo in page)
+
+
+def write_workflow_runs(repo, session):
+    first_page_url = WORKFLOW_RUNS_URL_TEMPLATE.format(repo=repo)
+    query_time = int(time.time())
+    output_dir = DATA_DIR / "workflow_runs" / repo / str(query_time)
+    for page_number, response in enumerate(
+        get_all_pages_with_retry(
+            session.get, first_page_url, params={"format": "json", "per_page": 100}
+        ),
+        start=1,
+    ):
+        page = response.json()["workflow_runs"]
+        write_json(
+            page,
+            output_dir / "pages" / f"page_{page_number}.json",
+        )
+        for run in page:
+            write_json(run, output_dir / "runs" / f"{run['id']}.json")

--- a/tests/test_get_workflow_runs.py
+++ b/tests/test_get_workflow_runs.py
@@ -1,0 +1,177 @@
+import pathlib
+
+import requests
+
+from tasks import get_workflow_runs
+
+
+class MockResponse:
+    def __init__(self, json_data, next_url="", error=""):
+        self.links = {"next": {"url": next_url}} if next_url else {}
+        self.json_data = json_data
+        self.error = error
+
+    def json(self):
+        return self.json_data
+
+    def raise_for_status(self):
+        if self.error:
+            raise requests.HTTPError(self.error)
+
+
+def test_github_api_session_init(monkeypatch):
+    monkeypatch.setenv("GITHUB_WORKFLOW_RUNS_TOKEN", "test_token")
+    session = get_workflow_runs.GitHubAPISession()
+    assert session.headers["Authorization"] == "Bearer test_token"
+
+
+def test_github_api_session_init_when_no_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_WORKFLOW_RUNS_TOKEN", raising=False)
+    session = get_workflow_runs.GitHubAPISession()
+    assert "Authorization" not in session.headers
+
+
+def test_retry_when_all_fail():
+    logs = []
+
+    @get_workflow_runs.retry(logs.append)
+    def get(url, **kwargs):
+        return MockResponse({}, error="Not Found")
+
+    get("failure_url")
+
+    assert logs == [
+        "Error fetching failure_url: Not Found\nRetrying in 0.5 seconds (retry attempt 1) ...",
+        "Error fetching failure_url: Not Found\nRetrying in 1.0 seconds (retry attempt 2) ...",
+        "Error fetching failure_url: Not Found\nRetrying in 2.0 seconds (retry attempt 3) ...",
+        "Error fetching failure_url: Not Found\nSkipping as maximum retries reached (3).",
+    ]
+
+
+def test_retry_when_successful_first_time():
+    logs = []
+
+    @get_workflow_runs.retry(logs.append)
+    def get(url, **kwargs):
+        return MockResponse({"data": ""})
+
+    response = get("success_url")
+
+    assert response.json() == {"data": ""}
+    assert logs == []
+
+
+def test_retry_when_successful_after_failure():
+    logs = []
+    responses = [
+        MockResponse({}, error="Temporary failure"),
+        MockResponse({}, error="Temporary failure"),
+        MockResponse({"data": ""}),
+    ]
+
+    @get_workflow_runs.retry(logs.append)
+    def get(url, **kwargs):
+        return responses.pop(0)
+
+    response = get("flaky_url")
+
+    assert response.json() == {"data": ""}
+    assert logs == [
+        "Error fetching flaky_url: Temporary failure\nRetrying in 0.5 seconds (retry attempt 1) ...",
+        "Error fetching flaky_url: Temporary failure\nRetrying in 1.0 seconds (retry attempt 2) ...",
+    ]
+
+
+def test_get_all_pages_with_retry():
+    urls_called = []
+    responses = [
+        MockResponse({"data": "page1"}, next_url="page2_url"),
+        MockResponse({"data": "page2"}),
+    ]
+
+    def get(url, **kwargs):
+        urls_called.append(url)
+        return responses.pop(0)
+
+    pages = list(get_workflow_runs.get_all_pages_with_retry(get, "start_url"))
+
+    assert urls_called == ["start_url", "page2_url"]
+    assert len(pages) == 2
+    assert pages[0].json() == {"data": "page1"}
+    assert pages[1].json() == {"data": "page2"}
+
+
+def test_get_all_pages_with_retry_when_failed():
+    urls_called = []
+    responses = [
+        MockResponse({"data": "page1"}, next_url="page2_url"),
+        MockResponse({"error": "Network error"}, error="Network error"),  # initial
+        MockResponse({"error": "Network error"}, error="Network error"),  # retry 1
+        MockResponse({"error": "Network error"}, error="Network error"),  # retry 2
+        MockResponse({"error": "Network error"}, error="Network error"),  # retry 3
+    ]
+
+    def get(url, **kwargs):
+        urls_called.append(url)
+        return responses.pop(0)
+
+    pages = list(get_workflow_runs.get_all_pages_with_retry(get, "start_url"))
+
+    assert urls_called == ["start_url"] + ["page2_url"] * 4
+    assert len(pages) == 1
+    assert pages[0].json() == {"data": "page1"}
+
+
+def test_get_repo_names(monkeypatch, capsys):
+    repos = [{"name": "repo1"}, {"name": "repo2"}]
+
+    class MockSession:
+        def get(self, url, **kwargs):
+            return MockResponse(repos)
+
+    with monkeypatch.context() as m:
+        m.setattr("time.time", lambda: 1000.1)
+        m.setattr(get_workflow_runs, "DATA_DIR", pathlib.Path("data"))
+
+        repo_names = list(get_workflow_runs.get_repo_names(MockSession()))
+
+    assert repo_names == ["repo1", "repo2"]
+    # write_json is currently just a placeholder that prints to the console
+    assert capsys.readouterr().out == (
+        "Writing a list of 2 items to data/workflow_runs/repos/1000/pages/page_1.json\n"
+    )
+
+
+def test_write_workflow_runs(monkeypatch, capsys):
+    urls_called = []
+    responses = [
+        MockResponse(
+            {"total_count": 3, "workflow_runs": [{"id": 1}, {"id": 2}]},
+            next_url="page2_url",
+        ),
+        MockResponse({"total_count": 3, "workflow_runs": [{"id": 3}]}),
+    ]
+
+    class MockSession:
+        def get(self, url, **kwargs):
+            urls_called.append(url)
+            return responses.pop(0)
+
+    with monkeypatch.context() as m:
+        m.setattr("time.time", lambda: 1000.1)
+        m.setattr(get_workflow_runs, "DATA_DIR", pathlib.Path("data"))
+
+        get_workflow_runs.write_workflow_runs("my_repo", MockSession())
+
+    assert urls_called == [
+        "https://api.github.com/repos/opensafely/my_repo/actions/runs",
+        "page2_url",
+    ]
+    # write_json is currently just a placeholder that prints to the console
+    assert capsys.readouterr().out == (
+        "Writing a list of 2 items to data/workflow_runs/my_repo/1000/pages/page_1.json\n"
+        "Writing a dict of 1 items to data/workflow_runs/my_repo/1000/runs/1.json\n"
+        "Writing a dict of 1 items to data/workflow_runs/my_repo/1000/runs/2.json\n"
+        "Writing a list of 1 items to data/workflow_runs/my_repo/1000/pages/page_2.json\n"
+        "Writing a dict of 1 items to data/workflow_runs/my_repo/1000/runs/3.json\n"
+    )


### PR DESCRIPTION
Add functions to retrieve workflow runs for GitHub Actions from the GitHub API. These functions will be used in a yet-to-be-written ETL pipeline in the `get_workflow_runs` task.

Note that timestamps are written as integers instead of human-readable strings as a first step to avoid having to parse dates for now.

Note also that there is a placeholder function to write JSON data to disk - this will later be replaced with an actual function residing in in `tasks/io.py`