### PR TITLE
Clarify wording about fine-grained PAT in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ethelred needs a Job Server database.
 [Job Server's developer documentation][3] tells you how to get one.
 
 Ethelred needs a fine-grained [Personal Access Token][4] (PAT) with the "Actions (read-only)" permission.
-The PAT should be owned by the opensafely organisation.
+The PAT should access resources owned by the opensafely organisation.
 
 When you've got a Job Server database and a PAT,
 copy `dotenv` to `.env` and, if necessary, update `.env`.


### PR DESCRIPTION
The fine-grained PAT itself should be owned and managed by the user, but the PAT's "Resource owner" should be the opensafely organisation.