### PR TITLE
Limit concurrency of CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yaml


### PR DESCRIPTION
Setting `concurrency.group` places all runs of the CD workflow within the same concurrency group, ensuring that only one run will run at a time. Setting `concurrency.cancel-in-progress` goes further and ensures that a new run will cancel an existing (in progress) run.

For more information about concurrency, see:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency

Closes #123