### PR TITLE
Add a fact table for OpenCodelists logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This Ethelred is:
 
 ## Setup
 
-Ethelred needs a Job Server database.
-[Job Server's developer documentation][3] tells you how to get one.
+Ethelred needs a Job Server PostgreSQL database and an OpenCodelists SQLite database.
+Refer to [Job Server's][3] and [OpenCodelists's][5] developer documentation for how to set these up.
 
 Ethelred needs a fine-grained [Personal Access Token][4] (PAT) with the "Actions (read-only)" permission.
 The PAT should access resources owned by the opensafely organisation.
 
-When you've got a Job Server database and a PAT,
+When you've got the databases and a PAT,
 copy `dotenv` to `.env` and, if necessary, update `.env`.
 
 Next, run the following commands:
@@ -31,6 +31,7 @@ python -m tasks.get_project_definitions
 python -m tasks.get_job_requests
 python -m tasks.get_jobs
 python -m tasks.get_workflow_runs
+python -m tasks.get_opencodelists_logins
 just run app/app.py
 ```
 
@@ -43,4 +44,5 @@ See the [README](docs/README.md) in the `docs` directory.
 [2]: https://en.wikipedia.org/wiki/%C3%86thelred_the_Unready
 [3]: https://github.com/opensafely-core/job-server/blob/main/DEVELOPERS.md
 [4]: https://github.com/settings/personal-access-tokens
+[5]: https://github.com/opensafely-core/opencodelists/blob/main/DEVELOPERS.md
 [Streamlit]: https://streamlit.io/

--- a/dotenv
+++ b/dotenv
@@ -1,2 +1,3 @@
 GITHUB_WORKFLOW_RUNS_TOKEN=
 JOBSERVER_DATABASE_URL=postgresql://user:pass@localhost:6543/jobserver
+OPENCODELISTS_DATABASE_URL=sqlite:///data/opencodelists/db.sqlite3

--- a/tasks/get_job_requests.py
+++ b/tasks/get_job_requests.py
@@ -80,7 +80,7 @@ def get_records(rows, project_definition_loader):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine()
+    engine = utils.get_engine(utils.Database.JOBSERVER)
     metadata = utils.get_metadata(engine)
     rows = extract(engine, metadata)
 

--- a/tasks/get_jobs.py
+++ b/tasks/get_jobs.py
@@ -116,7 +116,7 @@ def get_records(rows):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine()
+    engine = utils.get_engine(utils.Database.JOBSERVER)
     metadata = utils.get_metadata(engine)
     rows = (row for row in extract(engine, metadata) if row.run_command)
     records = get_records(rows)

--- a/tasks/get_opencodelists_logins.py
+++ b/tasks/get_opencodelists_logins.py
@@ -1,0 +1,51 @@
+import collections
+import datetime
+
+import sqlalchemy
+
+from . import DATA_DIR, io, utils
+
+
+Record = collections.namedtuple(
+    "Record",
+    [
+        "login_at",
+        "user",
+    ],
+)
+
+
+def extract(engine, metadata):  # pragma: no cover
+    # This is hard to test without a OpenCodelists DB, so we exclude it from coverage.
+    users = metadata.tables["opencodelists_user"]
+
+    stmt = sqlalchemy.select(
+        users.c.last_login,
+        users.c.email,
+    )
+
+    with engine.connect() as conn:
+        yield from conn.execute(stmt)
+
+
+def get_records(rows):
+    for row in rows:
+        yield Record(
+            row.last_login.replace(tzinfo=datetime.timezone.utc),
+            utils.hash_email(row.email),
+        )
+
+
+def main():  # pragma: no cover
+    # This is hard to test without a OpenCodelists DB, so we exclude it from coverage.
+    engine = utils.get_engine(utils.Database.OPENCODELISTS)
+    metadata = utils.get_metadata(engine)
+    rows = extract(engine, metadata)
+
+    records = get_records(rows)
+
+    io.write(records, DATA_DIR / "opencodelists_logins" / "opencodelists_logins.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/get_project_definitions.py
+++ b/tasks/get_project_definitions.py
@@ -43,7 +43,7 @@ def write_pickle(records, project_definitions_dir):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine()
+    engine = utils.get_engine(utils.Database.JOBSERVER)
     metadata = utils.get_metadata(engine)
 
     rows = extract(engine, metadata)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,3 +1,4 @@
+import enum
 import os
 
 import sqlalchemy
@@ -5,8 +6,16 @@ import sqlalchemy
 from . import io
 
 
-def get_engine():
-    return sqlalchemy.create_engine(os.environ["JOBSERVER_DATABASE_URL"])
+class Database(enum.StrEnum):
+    JOBSERVER = enum.auto()
+
+
+def get_engine(database):
+    match database:
+        case Database.JOBSERVER:
+            return sqlalchemy.create_engine(os.environ["JOBSERVER_DATABASE_URL"])
+        case _:
+            raise TypeError(f"Cannot get engine for unknown database: {database}")
 
 
 def get_metadata(engine):

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,4 +1,5 @@
 import enum
+import hashlib
 import os
 
 import sqlalchemy
@@ -8,12 +9,15 @@ from . import io
 
 class Database(enum.StrEnum):
     JOBSERVER = enum.auto()
+    OPENCODELISTS = enum.auto()
 
 
 def get_engine(database):
     match database:
         case Database.JOBSERVER:
             return sqlalchemy.create_engine(os.environ["JOBSERVER_DATABASE_URL"])
+        case Database.OPENCODELISTS:
+            return sqlalchemy.create_engine(os.environ["OPENCODELISTS_DATABASE_URL"])
         case _:
             raise TypeError(f"Cannot get engine for unknown database: {database}")
 
@@ -30,3 +34,7 @@ def get_repo(url):
 
 def load_project_definition(project_definitions_dir, repo, sha):
     return io.read(project_definitions_dir / repo / f"{sha}.pickle")
+
+
+def hash_email(email):
+    return hashlib.sha256(email.encode("utf-8")).hexdigest()

--- a/tests/jobserver/get_tables.py
+++ b/tests/jobserver/get_tables.py
@@ -56,7 +56,7 @@ def get_table(table):
 
 
 def main():
-    engine = utils.get_engine()
+    engine = utils.get_engine(utils.Database.JOBSERVER)
     metadata = utils.get_metadata(engine)
     d_path = pathlib.Path(__file__).parent
     f_path = d_path / "tables.py"

--- a/tests/tasks/test_get_opencodelists_logins.py
+++ b/tests/tasks/test_get_opencodelists_logins.py
@@ -1,0 +1,21 @@
+import collections
+import datetime
+
+from tasks import get_opencodelists_logins, utils
+
+
+Row = collections.namedtuple("Row", ["last_login", "email"])
+
+
+def test_get_records():
+    row = Row(
+        last_login=datetime.datetime(2025, 1, 1, tzinfo=None),
+        email="user@example.com",
+    )
+    records = list(get_opencodelists_logins.get_records([row]))
+    record = records[0]
+
+    assert record.login_at == datetime.datetime(
+        2025, 1, 1, tzinfo=datetime.timezone.utc
+    )
+    assert record.user == utils.hash_email("user@example.com")

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -3,9 +3,16 @@ import pytest
 from tasks import io, utils
 
 
-def test_get_engine(monkeypatch):
-    monkeypatch.setenv("JOBSERVER_DATABASE_URL", "sqlite+pysqlite:///:memory:")
-    engine = utils.get_engine(utils.Database.JOBSERVER)
+@pytest.mark.parametrize(
+    "database, environment_variable",
+    [
+        (utils.Database.JOBSERVER, "JOBSERVER_DATABASE_URL"),
+        (utils.Database.OPENCODELISTS, "OPENCODELISTS_DATABASE_URL"),
+    ],
+)
+def test_get_engine(database, environment_variable, monkeypatch):
+    monkeypatch.setenv(environment_variable, "sqlite+pysqlite:///:memory:")
+    engine = utils.get_engine(database)
     assert str(engine.url) == "sqlite+pysqlite:///:memory:"
 
 
@@ -29,3 +36,9 @@ def test_load_project_definition(tmp_path):
     io.write({}, tmp_path / "my-repo" / "0000000.pickle")
     project_definition = utils.load_project_definition(tmp_path, "my-repo", "0000000")
     assert project_definition == {}
+
+
+def test_hash_email():
+    email = "user@example.com"
+    hashed = utils.hash_email(email)
+    assert hashed == "b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514"

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -1,15 +1,22 @@
+import pytest
+
 from tasks import io, utils
 
 
 def test_get_engine(monkeypatch):
     monkeypatch.setenv("JOBSERVER_DATABASE_URL", "sqlite+pysqlite:///:memory:")
-    engine = utils.get_engine()
+    engine = utils.get_engine(utils.Database.JOBSERVER)
     assert str(engine.url) == "sqlite+pysqlite:///:memory:"
+
+
+def test_get_engine_when_unknown_database():
+    with pytest.raises(TypeError, match="Cannot get engine for unknown database: foo"):
+        utils.get_engine("foo")
 
 
 def test_get_metadata(monkeypatch):
     monkeypatch.setenv("JOBSERVER_DATABASE_URL", "sqlite+pysqlite:///:memory:")
-    metadata = utils.get_metadata(utils.get_engine())
+    metadata = utils.get_metadata(utils.get_engine(utils.Database.JOBSERVER))
     assert metadata.tables == {}
 
 


### PR DESCRIPTION
Closes #102 .

- Add OpenCodelists (OC) as a new data source for ethelred and requires a copy of the OC database to run the repo
- Have `utils.get_engine` in `utils.py` take a `Database` string enum object as its argument, as we now have two databases to make connections to.
- Add a ETL task to connect to the OC database and extract the timestamp of the last time a user has logged in, along with a SHA-256 hash of the corresponding user's email address.
- Note that as per specification in the ticket, the tables in the OC database have not been reflected into SQLAlchemy objects for testing; instead, the functions that require a database connection have been `pragma: no cover`-ed.

Implementation details are given in the commit messages.

To test this branch, first copy `dotenv` to `.env`, or add the following line to `.env`:
https://github.com/opensafely-core/ethelred/blob/0fde374/dotenv#L3

Then, copy the `db.sqlite3` file corresponding to a local instance of the OpenCodelists database to the path specified in the `.env`. The task can then be run in an activated virtualenv using `python -m tasks.get_opencodelists_logins`.