### PR TITLE
Move DB utilities from `utils` to `db`

### DIFF
--- a/tasks/db.py
+++ b/tasks/db.py
@@ -1,0 +1,25 @@
+import enum
+import os
+
+import sqlalchemy
+
+
+class Database(enum.StrEnum):
+    JOBSERVER = enum.auto()
+    OPENCODELISTS = enum.auto()
+
+
+def get_engine(database):
+    match database:
+        case Database.JOBSERVER:
+            return sqlalchemy.create_engine(os.environ["JOBSERVER_DATABASE_URL"])
+        case Database.OPENCODELISTS:
+            return sqlalchemy.create_engine(os.environ["OPENCODELISTS_DATABASE_URL"])
+        case _:
+            raise TypeError(f"Cannot get engine for unknown database: {database}")
+
+
+def get_metadata(engine):
+    metadata = sqlalchemy.MetaData()
+    metadata.reflect(bind=engine)
+    return metadata

--- a/tasks/tasks/get_job_requests.py
+++ b/tasks/tasks/get_job_requests.py
@@ -3,7 +3,7 @@ import functools
 
 import sqlalchemy
 
-from .. import DATA_DIR, INDEX_DATE, io, utils
+from .. import DATA_DIR, INDEX_DATE, db, io, utils
 
 
 Record = collections.namedtuple(
@@ -80,8 +80,8 @@ def get_records(rows, project_definition_loader):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine(utils.Database.JOBSERVER)
-    metadata = utils.get_metadata(engine)
+    engine = db.get_engine(db.Database.JOBSERVER)
+    metadata = db.get_metadata(engine)
     rows = extract(engine, metadata)
 
     project_definition_loader = functools.partial(

--- a/tasks/tasks/get_jobs.py
+++ b/tasks/tasks/get_jobs.py
@@ -3,7 +3,7 @@ import enum
 
 import sqlalchemy
 
-from .. import DATA_DIR, INDEX_DATE, io, utils
+from .. import DATA_DIR, INDEX_DATE, db, io
 
 
 Record = collections.namedtuple(
@@ -116,8 +116,8 @@ def get_records(rows):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine(utils.Database.JOBSERVER)
-    metadata = utils.get_metadata(engine)
+    engine = db.get_engine(db.Database.JOBSERVER)
+    metadata = db.get_metadata(engine)
     rows = (row for row in extract(engine, metadata) if row.run_command)
     records = get_records(rows)
     io.write(records, DATA_DIR / "jobs" / "jobs.csv")

--- a/tasks/tasks/get_opencodelists_logins.py
+++ b/tasks/tasks/get_opencodelists_logins.py
@@ -3,7 +3,7 @@ import datetime
 
 import sqlalchemy
 
-from .. import DATA_DIR, io, utils
+from .. import DATA_DIR, db, io, utils
 
 
 Record = collections.namedtuple(
@@ -38,8 +38,8 @@ def get_records(rows):
 
 def main():  # pragma: no cover
     # This is hard to test without a OpenCodelists DB, so we exclude it from coverage.
-    engine = utils.get_engine(utils.Database.OPENCODELISTS)
-    metadata = utils.get_metadata(engine)
+    engine = db.get_engine(db.Database.OPENCODELISTS)
+    metadata = db.get_metadata(engine)
     rows = extract(engine, metadata)
 
     records = get_records(rows)

--- a/tasks/tasks/get_project_definitions.py
+++ b/tasks/tasks/get_project_definitions.py
@@ -3,7 +3,7 @@ import collections
 import pipeline
 import sqlalchemy
 
-from .. import DATA_DIR, INDEX_DATE, io, utils
+from .. import DATA_DIR, INDEX_DATE, db, io, utils
 
 
 Record = collections.namedtuple("Record", ["repo", "sha", "project_definition"])
@@ -43,8 +43,8 @@ def write_pickle(records, project_definitions_dir):
 
 def main():  # pragma: no cover
     # This is hard to test without a Job Server DB, so we exclude it from coverage.
-    engine = utils.get_engine(utils.Database.JOBSERVER)
-    metadata = utils.get_metadata(engine)
+    engine = db.get_engine(db.Database.JOBSERVER)
+    metadata = db.get_metadata(engine)
 
     rows = extract(engine, metadata)
     records = (get_record(row) for row in rows)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -1,31 +1,6 @@
-import enum
 import hashlib
-import os
-
-import sqlalchemy
 
 from . import io
-
-
-class Database(enum.StrEnum):
-    JOBSERVER = enum.auto()
-    OPENCODELISTS = enum.auto()
-
-
-def get_engine(database):
-    match database:
-        case Database.JOBSERVER:
-            return sqlalchemy.create_engine(os.environ["JOBSERVER_DATABASE_URL"])
-        case Database.OPENCODELISTS:
-            return sqlalchemy.create_engine(os.environ["OPENCODELISTS_DATABASE_URL"])
-        case _:
-            raise TypeError(f"Cannot get engine for unknown database: {database}")
-
-
-def get_metadata(engine):
-    metadata = sqlalchemy.MetaData()
-    metadata.reflect(bind=engine)
-    return metadata
 
 
 def get_repo(url):

--- a/tests/tasks/test_db.py
+++ b/tests/tasks/test_db.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tasks import db
+
+
+@pytest.mark.parametrize(
+    "database, environment_variable",
+    [
+        (db.Database.JOBSERVER, "JOBSERVER_DATABASE_URL"),
+        (db.Database.OPENCODELISTS, "OPENCODELISTS_DATABASE_URL"),
+    ],
+)
+def test_get_engine(database, environment_variable, monkeypatch):
+    monkeypatch.setenv(environment_variable, "sqlite+pysqlite:///:memory:")
+    engine = db.get_engine(database)
+    assert str(engine.url) == "sqlite+pysqlite:///:memory:"
+
+
+def test_get_engine_when_unknown_database():
+    with pytest.raises(TypeError, match="Cannot get engine for unknown database: foo"):
+        db.get_engine("foo")
+
+
+def test_get_metadata(monkeypatch):
+    monkeypatch.setenv("JOBSERVER_DATABASE_URL", "sqlite+pysqlite:///:memory:")
+    metadata = db.get_metadata(db.get_engine(db.Database.JOBSERVER))
+    assert metadata.tables == {}

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -1,30 +1,4 @@
-import pytest
-
 from tasks import io, utils
-
-
-@pytest.mark.parametrize(
-    "database, environment_variable",
-    [
-        (utils.Database.JOBSERVER, "JOBSERVER_DATABASE_URL"),
-        (utils.Database.OPENCODELISTS, "OPENCODELISTS_DATABASE_URL"),
-    ],
-)
-def test_get_engine(database, environment_variable, monkeypatch):
-    monkeypatch.setenv(environment_variable, "sqlite+pysqlite:///:memory:")
-    engine = utils.get_engine(database)
-    assert str(engine.url) == "sqlite+pysqlite:///:memory:"
-
-
-def test_get_engine_when_unknown_database():
-    with pytest.raises(TypeError, match="Cannot get engine for unknown database: foo"):
-        utils.get_engine("foo")
-
-
-def test_get_metadata(monkeypatch):
-    monkeypatch.setenv("JOBSERVER_DATABASE_URL", "sqlite+pysqlite:///:memory:")
-    metadata = utils.get_metadata(utils.get_engine(utils.Database.JOBSERVER))
-    assert metadata.tables == {}
 
 
 def test_get_repo():


### PR DESCRIPTION
The problem with `utils` modules is that they very quickly become disorganised. Let's move those utilities that relate to databases to their own module, which we'll call `db`.