### PR TITLE
Update `get_records` to handle missing `last_login`

### DIFF
--- a/tasks/tasks/get_opencodelists_logins.py
+++ b/tasks/tasks/get_opencodelists_logins.py
@@ -19,10 +19,11 @@ def extract(engine, metadata):  # pragma: no cover
 
 def get_records(rows):
     for row in rows:
-        yield Record(
-            row.last_login.replace(tzinfo=datetime.timezone.utc),
-            utils.sha256(row.email),
-        )
+        if row.last_login is None:
+            last_login = row.last_login
+        else:
+            last_login = row.last_login.replace(tzinfo=datetime.timezone.utc)
+        yield Record(last_login, utils.sha256(row.email))
 
 
 def main():  # pragma: no cover

--- a/tests/tasks/tasks/test_get_opencodelists_logins.py
+++ b/tests/tasks/tasks/test_get_opencodelists_logins.py
@@ -17,7 +17,7 @@ Row = collections.namedtuple("Row", ["last_login", "email"])
             datetime.datetime(2025, 1, 1, tzinfo=None),
             datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc),
         ),
-        pytest.param(None, None, marks=pytest.mark.xfail(raises=AttributeError)),
+        (None, None),
     ],
 )
 def test_get_records(last_login, login_at):


### PR DESCRIPTION
There are a small number of cases where `last_login` is missing (`None`).