### PR TITLE
Pare back `app/app.py` and the repositories

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -7,10 +7,7 @@ import repositories
 def main(repository):  # pragma: no cover
     # This is tested by tests.app.test_app.test_app, but coverage doesn't seem to
     # realise.
-    repository.get_date_earliest_job_request_created()
-    repository.get_date_latest_job_request_created()
-
-    repository.get_job_requests(None, None)
+    ...
 
 
 if __name__ == "__main__":

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -1,52 +1,10 @@
 import abc
 import pathlib
 
-import pandas
 
-
-class AbstractRepository(abc.ABC):
-    @abc.abstractmethod
-    def get_date_earliest_job_request_created(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_date_latest_job_request_created(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_job_requests(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_jobs(self):
-        raise NotImplementedError
+class AbstractRepository(abc.ABC): ...
 
 
 class Repository(AbstractRepository):
     def __init__(self, root_dir):
         root_dir = pathlib.Path(root_dir)
-        self.job_requests_csv = root_dir / "job_requests" / "job_requests.csv"
-        self.jobs_csv = root_dir / "jobs" / "jobs.csv"
-
-    @property
-    def _job_requests(self):
-        return pandas.read_csv(self.job_requests_csv, parse_dates=["created_at"])
-
-    def get_date_earliest_job_request_created(self):
-        return self._job_requests["created_at"].min().to_pydatetime().date()
-
-    def get_date_latest_job_request_created(self):
-        return self._job_requests["created_at"].max().to_pydatetime().date()
-
-    def get_job_requests(self, from_, to_):
-        assert from_ <= to_
-        # Indexing into a DatetimeIndex with a string when a datetime.date is available
-        # feels wrong, but the alternatives are cumbersome.
-        from_, to_ = [x.isoformat() for x in (from_, to_)]
-        by_created_at = self._job_requests.set_index(
-            "created_at", drop=False
-        ).sort_index()
-        return by_created_at.loc[from_:to_].reset_index(drop=True)
-
-    def get_jobs(self):
-        return pandas.read_csv(self.jobs_csv)

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,32 +1,9 @@
-import datetime
-
-import pandas
 from streamlit.testing.v1 import AppTest
 
 from app import app, repositories
 
 
-class FakeRepository(repositories.AbstractRepository):
-    def get_date_earliest_job_request_created(self):
-        return datetime.datetime(2025, 1, 1)
-
-    def get_date_latest_job_request_created(self):
-        return datetime.datetime(2025, 2, 1)
-
-    def get_job_requests(self, from_, to_):
-        return pandas.DataFrame(
-            {
-                "created_at": [
-                    datetime.datetime(2025, 1, 1),
-                    datetime.datetime(2025, 2, 1),
-                ],
-                "num_actions": [1, 1],
-                "num_jobs": [1, 1],
-                "username": ["a_user", "a_user"],
-            }
-        )
-
-    def get_jobs(self): ...  # pragma: no cover
+class FakeRepository(repositories.AbstractRepository): ...
 
 
 def test_app():

--- a/tests/app/test_repositories.py
+++ b/tests/app/test_repositories.py
@@ -1,10 +1,9 @@
-import datetime
-
 import pytest
 
 from app import repositories
 
 
+@pytest.mark.xfail
 def test_abstract_repository():
     class FakeRepository(repositories.AbstractRepository): ...
 
@@ -12,51 +11,5 @@ def test_abstract_repository():
         FakeRepository()
 
 
-@pytest.fixture
-def repository(tmp_path):
-    job_requests_path = tmp_path / "job_requests" / "job_requests.csv"
-    job_requests_path.parent.mkdir()
-    # This fixture doesn't have to correspond to whatever tasks/get_job_requests.py
-    # would write. It just has to exercise Repository.get_job_requests.
-    job_requests_path.write_text(
-        # rows are intentionally not sorted
-        "id,created_at\n"
-        + "1,2025-01-01T00:00:00Z\n"
-        + "3,2025-06-01T00:00:00Z\n"
-        + "2,2025-03-01T00:00:00Z\n"
-    )
-
-    jobs_path = tmp_path / "jobs" / "jobs.csv"
-    jobs_path.parent.mkdir()
-    # This fixture doesn't have to correspond to whatever tasks/get_jobs.py
-    # would write. It just has to exercise Repository.get_jobs.
-    jobs_path.write_text("id,job_request_id\n" + "10,1\n" + "20,2\n" + "30,3")
-
-    return repositories.Repository(tmp_path)
-
-
-def test_get_date_earliest_job_request_created(repository):
-    created_at = repository.get_date_earliest_job_request_created()
-    assert created_at == datetime.date(2025, 1, 1)
-
-
-def test_get_date_latest_job_request_created(repository):
-    created_at = repository.get_date_latest_job_request_created()
-    assert created_at == datetime.date(2025, 6, 1)
-
-
-def test_repository_get_job_requests(repository):
-    from_ = datetime.date(2025, 1, 1)
-    to_ = datetime.date(2025, 3, 1)
-    job_requests = repository.get_job_requests(from_, to_)
-    assert list(job_requests["id"]) == [1, 2]
-    # Accessing .dt on a series that doesn't contain datetimelike values will raise an
-    # AttributeError. The assertion isn't important; it's here because we expect to see
-    # an assertion.
-    assert job_requests["created_at"].dt.name == "created_at"
-
-
-def test_repository_get_jobs(repository):
-    jobs = repository.get_jobs()
-    assert list(jobs["id"]) == [10, 20, 30]
-    assert list(jobs["job_request_id"]) == [1, 2, 3]
+def test_repository(tmp_path):
+    assert repositories.Repository(tmp_path)


### PR DESCRIPTION
We don't want to be hidebound by our existing dashboard when working on #131, so we first pare back `app/app.py` and the repositories. I considered paring back `app/charts.py` too, but it's very likely that we'll need them soon, and they stand alone.