### PR TITLE
Represent number of logins per day on timeseries

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 
 import repositories
 
@@ -7,10 +6,61 @@ import repositories
 def main(repository):  # pragma: no cover
     # This is tested by tests.app.test_app.test_app, but coverage doesn't seem to
     # realise.
-    ...
+    import altair
+    import streamlit
+
+    with streamlit.sidebar:
+        earliest_login_date = repository.get_earliest_login_date()
+        latest_login_date = repository.get_latest_login_date()
+
+        initial_from = latest_login_date.replace(month=1, day=1)
+        from_ = streamlit.date_input(
+            "From",
+            value=initial_from,
+            min_value=earliest_login_date,
+            max_value=latest_login_date,
+            help="The earliest date to include",
+        )
+
+        initial_to = latest_login_date
+        to_ = streamlit.date_input(
+            "To",
+            value=initial_to,
+            min_value=earliest_login_date,
+            max_value=latest_login_date,
+            help="The latest date to include",
+        )
+
+        if not from_ < to_:
+            streamlit.error("The *From* date must come before the *To* date.")
+            from_ = initial_from
+            to_ = initial_to
+
+    streamlit.title("Ethelred")
+
+    streamlit.header("OpenCodelists")
+
+    streamlit.markdown(
+        f"Number of logins per day from {from_:%Y/%m/%d} to {to_:%Y/%m/%d} in blue, "
+        + "compared to the 28 day rolling mean in red"
+    )
+
+    base_chart = altair.Chart(repository.get_logins_per_day(from_, to_))
+    count_chart = base_chart.mark_line().encode(x="date", y="count")
+    rolling_mean_chart = (
+        base_chart.mark_line(color="red")
+        .transform_window(rolling_mean="mean(count)", frame=[-27, 0])
+        .encode(x="date", y="rolling_mean:Q")
+    )
+    layer_chart = (
+        (count_chart + rolling_mean_chart)
+        .configure_axis(title=None)
+        .configure_line(interpolate="monotone")
+    )
+    streamlit.write(layer_chart)
 
 
 if __name__ == "__main__":
-    DATA_DIR = pathlib.Path(os.environ.get("DATA_DIR", "data"))
-    repository = repositories.Repository(DATA_DIR)
+    database_url = os.environ.get("ETHELRED_DATABASE_URL")
+    repository = repositories.Repository(database_url)
     main(repository)

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -1,10 +1,42 @@
 import abc
-import pathlib
+
+import pandas
 
 
-class AbstractRepository(abc.ABC): ...
+class AbstractRepository(abc.ABC):
+    @abc.abstractmethod
+    def get_earliest_login_date(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_latest_login_date(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_logins_per_day(self, from_, to_):
+        raise NotImplementedError
 
 
 class Repository(AbstractRepository):
-    def __init__(self, root_dir):
-        root_dir = pathlib.Path(root_dir)
+    def __init__(self, database_url):
+        self._logins = pandas.read_sql_table("opencodelists_logins", database_url)
+
+    def get_earliest_login_date(self):
+        return self._logins["login_at"].min().to_pydatetime()
+
+    def get_latest_login_date(self):
+        return self._logins["login_at"].max().to_pydatetime()
+
+    def get_logins_per_day(self, from_, to_):
+        assert from_ <= to_
+        # Indexing into a DatetimeIndex with a string when a datetime.date is available
+        # feels wrong, but the alternatives are cumbersome.
+        from_, to_ = [x.isoformat() for x in (from_, to_)]
+        logins = self._logins.set_index("login_at").sort_index().loc[from_:to_]
+        logins_per_day = (
+            logins.resample("D")
+            .count()
+            .reset_index()
+            .rename(columns={"login_at": "date", "email_hash": "count"})
+        )
+        return logins_per_day

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -1,9 +1,20 @@
+import datetime
+
+import pandas
 from streamlit.testing.v1 import AppTest
 
 from app import app, repositories
 
 
-class FakeRepository(repositories.AbstractRepository): ...
+class FakeRepository(repositories.AbstractRepository):
+    def get_earliest_login_date(self):
+        return datetime.date(2025, 1, 1)
+
+    def get_latest_login_date(self):
+        return datetime.date(2025, 1, 1)
+
+    def get_logins_per_day(self, from_, to_):
+        return pandas.DataFrame({"date": [datetime.date(2025, 1, 1)], "count": [1]})
 
 
 def test_app():

--- a/tests/app/test_repositories.py
+++ b/tests/app/test_repositories.py
@@ -1,9 +1,11 @@
+import datetime
+
 import pytest
+import sqlalchemy
 
 from app import repositories
 
 
-@pytest.mark.xfail
 def test_abstract_repository():
     class FakeRepository(repositories.AbstractRepository): ...
 
@@ -11,5 +13,43 @@ def test_abstract_repository():
         FakeRepository()
 
 
-def test_repository(tmp_path):
-    assert repositories.Repository(tmp_path)
+@pytest.fixture
+def repository(tmp_path):
+    database_url = f"sqlite+pysqlite:///{tmp_path}/db.sqlite3"
+    engine = sqlalchemy.create_engine(database_url)
+    metadata = sqlalchemy.MetaData()
+    logins_table = sqlalchemy.Table(
+        "opencodelists_logins",
+        metadata,
+        sqlalchemy.Column("login_at", sqlalchemy.DateTime, primary_key=True),
+        sqlalchemy.Column("email_hash", sqlalchemy.String(64), primary_key=True),
+    )
+    metadata.create_all(engine)
+    with engine.connect() as conn:
+        logins = [
+            {"login_at": datetime.datetime(2025, 1, 1), "email_hash": 1111111},
+            {"login_at": datetime.datetime(2025, 1, 3), "email_hash": 3333333},
+        ]
+        conn.execute(sqlalchemy.insert(logins_table), logins)
+        conn.commit()
+    return repositories.Repository(database_url)
+
+
+def test_get_earliest_login_date(repository):
+    assert repository.get_earliest_login_date() == datetime.datetime(2025, 1, 1)
+
+
+def test_get_latest_login_date(repository):
+    assert repository.get_latest_login_date() == datetime.datetime(2025, 1, 3)
+
+
+def test_get_logins_per_day(repository):
+    logins_per_day = repository.get_logins_per_day(
+        datetime.date(2025, 1, 1), datetime.date(2025, 1, 3)
+    )
+    assert list(logins_per_day["date"].dt.to_pydatetime()) == [
+        datetime.datetime(2025, 1, 1),
+        datetime.datetime(2025, 1, 2),  # not in fixture data
+        datetime.datetime(2025, 1, 3),
+    ]
+    assert list(logins_per_day["count"]) == [1, 0, 1]


### PR DESCRIPTION
As well as the timeseries, we also update the repository. For convenience, we simply read the `opencodelists_logins` table into a Pandas data frame.

Closes #131