### PR TITLE
Fix `pytest`

### DIFF
--- a/docs/decision_records.md
+++ b/docs/decision_records.md
@@ -178,8 +178,7 @@ Not using the standard import system means we need to add some configuration to 
 * and most importantly, nobody is confused.
 
 More specifically,
-we set `tool.ruff.src` in `pyproject.toml`
-and `PYTHONPATH` when invoking Coverage.py with `just test`.
+we set `tool.ruff.src` and `tool.pytest.ini_options.pythonpath` in `pyproject.toml`.
 
 ## 010: GitHub flow
 

--- a/justfile
+++ b/justfile
@@ -68,7 +68,7 @@ run *args: prodenv
 
 # Run tests
 test *args: devenv
-    PYTHONPATH={{ justfile_directory() }}/app {{ BIN_DIR }}/coverage run --source {{ justfile_directory() }} --module pytest {{ args }}
+    {{ BIN_DIR }}/coverage run --source {{ justfile_directory() }} --module pytest {{ args }}
     {{ BIN_DIR }}/coverage report || {{ BIN_DIR }}/coverage html
 
 # Fix code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ filterwarnings = [
     # control Streamlit, so we ignore the deprecation warning.
     "ignore::altair.utils.deprecation.AltairDeprecationWarning:streamlit.elements.vega_charts",
 ]
+pythonpath = "app"
 
 [tool.ruff]
 src = [".", "app"]


### PR DESCRIPTION
Because Streamlit apps aren't imported using the standard import system, we previously set `PYTHONPATH` in the `test` Just recipe. However, this didn't apply when calling `pytest` directly. A better approach is to set `tool.pytest.ini_options.pythonpath`, which applies to all invocations of `pytest`, so that is what I've done here.

I've updated the associated decision record ([DR009][]). Whilst updating decision records isn't a good idea ([DR000][]), inaccurate information is worse.

[DR000]: https://github.com/opensafely-core/ethelred/blob/main/docs/decision_records.md#000-decisions-and-their-records
[DR009]: https://github.com/opensafely-core/ethelred/blob/main/docs/decision_records.md#009-source-directories-and-pythonpath