### PR TITLE
Remove `AbstractRepository`

### DIFF
--- a/app/repositories.py
+++ b/app/repositories.py
@@ -1,29 +1,9 @@
-import abc
-
 import duckdb
 import pandas
 from duckdb import sqltypes
 
 
-class AbstractRepository(abc.ABC):
-    @abc.abstractmethod
-    def get_earliest_login_event_date(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_latest_login_event_date(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_login_events_per_day(self, from_, to_):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_codelist_create_events_per_day(self, from_, to_):
-        raise NotImplementedError
-
-
-class Repository(AbstractRepository):
+class Repository:
     def __init__(self, root_uri):
         self.login_events_uri = root_uri + "/opencodelists/login_events.csv"
         self.codelist_create_events_uri = (

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -3,10 +3,10 @@ import datetime
 import pandas
 from streamlit.testing.v1 import AppTest
 
-from app import app, repositories
+from app import app
 
 
-class FakeRepository(repositories.AbstractRepository):
+class FakeRepository:
     def get_earliest_login_event_date(self):
         return datetime.date(2025, 1, 1)
 

--- a/tests/app/test_repositories.py
+++ b/tests/app/test_repositories.py
@@ -5,13 +5,6 @@ import pytest
 from app import repositories
 
 
-def test_abstract_repository():
-    class FakeRepository(repositories.AbstractRepository): ...
-
-    with pytest.raises(TypeError):
-        FakeRepository()
-
-
 @pytest.fixture
 def repository(tmp_path):
     path = tmp_path / "opencodelists"


### PR DESCRIPTION
We're not getting value for money from `AbstractRepository` (f7ef160, 8a7b25a, 0c90937, #167), so let's remove it.