### PR TITLE
Refactor repository

### DIFF
--- a/app/repositories.py
+++ b/app/repositories.py
@@ -10,10 +10,10 @@ class Repository:
             root_uri + "/opencodelists/codelist_create_events.csv"
         )
 
-    def get_earliest_login_event_date(self):
+    def get_earliest_login_event_date(self):  # pragma: no cover
         return _get_scalar_result(self.login_events_uri, "min", "login_at").date()
 
-    def get_latest_login_event_date(self):
+    def get_latest_login_event_date(self):  # pragma: no cover
         return _get_scalar_result(self.login_events_uri, "max", "login_at").date()
 
     def get_login_events_per_day(self, from_, to_):  # pragma: no cover

--- a/tests/app/test_repositories.py
+++ b/tests/app/test_repositories.py
@@ -1,35 +1,18 @@
 import datetime
+import pathlib
+from urllib.parse import urlparse
 
 import pytest
 
 from app import repositories
 
 
-@pytest.fixture
-def repository(tmp_path):
-    path = tmp_path / "opencodelists"
-    path.mkdir()
-    login_events_csv = path / "login_events.csv"
-    login_events_csv.write_text(
-        (
-            "login_at,email_hash\n"
-            + "2025-01-01 00:00:00,1111111\n"
-            + "2025-01-03 00:00:00,3333333\n"
-        )
-    )
-    codelist_create_events_csv = path / "codelist_create_events.csv"
-    codelist_create_events_csv.write_text(
-        ("created_at,id\n" + "2025-01-01 00:00:00,1\n" + "2025-01-03 00:00:00,3\n")
-    )
-    return repositories.Repository(tmp_path.as_uri())
-
-
-def test_get_earliest_login_event_date(repository):
-    assert repository.get_earliest_login_event_date() == datetime.date(2025, 1, 1)
-
-
-def test_get_latest_login_event_date(repository):
-    assert repository.get_latest_login_event_date() == datetime.date(2025, 1, 3)
+def test_repository_uris_have_valid_paths(tmp_path):
+    repository = repositories.Repository(tmp_path.as_uri())
+    login_events_path = urlparse(repository.login_events_uri).path
+    codelist_create_events_path = urlparse(repository.codelist_create_events_uri).path
+    assert str(pathlib.Path(login_events_path)) == login_events_path
+    assert str(pathlib.Path(codelist_create_events_path)) == codelist_create_events_path
 
 
 def test_get_scalar_result(tmp_path):


### PR DESCRIPTION
As with #168, this refactors the repository to make it easier to test the logic.

Given the pragmas, you may be wondering, "What's the repository for?" I think its contribution is to provide an interface between the Streamlit app and the data. Having such an interface means that if we decide to replace DuckDB, then we know where to replace it.