### PR TITLE
Add number of logged in users to dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -41,6 +41,14 @@ def main(repository):  # pragma: no cover
 
     streamlit.header("OpenCodelists")
 
+    streamlit.metric(
+        "Number of logged in users",
+        "{:,}".format(repository.get_num_logged_in_users(from_, to_)),
+        border=True,
+        help="The number of logged in users "
+        + f"from {from_:%Y/%m/%d} to {to_:%Y/%m/%d}",
+    )
+
     streamlit.markdown(
         f"Number of login events per day from {from_:%Y/%m/%d} to {to_:%Y/%m/%d} in blue, "
         + "compared to the 28 day rolling mean in red"

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -20,6 +20,16 @@ class Repository:
     def get_login_events_per_day(self, from_, to_):  # pragma: no cover
         return _get_events_per_day(self.uris["login_events"], "login_at", from_, to_)
 
+    def get_num_logged_in_users(self, from_, to_):
+        with duckdb.connect() as conn:
+            rel = conn.read_csv(self.uris["login_events"])
+            login_at = duckdb.ColumnExpression("login_at")
+            rel = rel.filter(login_at >= from_)
+            rel = rel.filter(login_at <= to_)
+            rel = rel.select("email_hash").distinct().count("email_hash")
+            val, *_ = rel.fetchone()
+        return val
+
     def get_codelist_create_events_per_day(self, from_, to_):  # pragma: no cover
         return _get_events_per_day(
             self.uris["codelist_create_events"], "created_at", from_, to_

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -16,6 +16,9 @@ class FakeRepository:
     def get_login_events_per_day(self, from_, to_):
         return pandas.DataFrame({"date": [datetime.date(2025, 1, 1)], "count": [1]})
 
+    def get_num_logged_in_users(self, from_, to_):
+        return 1_000
+
     def get_codelist_create_events_per_day(self, from_, to_):
         return pandas.DataFrame({"date": [datetime.date(2025, 1, 1)], "count": [1]})
 

--- a/tests/app/test_repositories.py
+++ b/tests/app/test_repositories.py
@@ -14,6 +14,23 @@ def test_repository_uris_have_valid_paths(tmp_path):
         assert str(pathlib.Path(path)) == path
 
 
+def test_repository_get_num_logged_in_users(tmp_path):
+    login_events_csv = tmp_path / "opencodelists" / "login_events.csv"
+    login_events_csv.parent.mkdir()
+    login_events_csv.write_text(
+        "login_at,email_hash\n"
+        + "2025-01-01 00:00:00,1111111\n"  # left boundary, should be counted
+        + "2025-01-02 00:00:00,1111111\n"  # logged in twice, shouldn't be counted
+        + "2025-01-03 00:00:00,2222222\n"  # right boundary, should be counted
+        + "2025-01-04 00:00:00,3333333\n"  # outside boundary, shouldn't be counted
+    )
+
+    repository = repositories.Repository(tmp_path.as_uri())
+    from_ = datetime.date(2025, 1, 1)
+    to_ = datetime.date(2025, 1, 3)
+    assert repository.get_num_logged_in_users(from_, to_) == 2
+
+
 def test_get_scalar_result(tmp_path):
     my_csv = tmp_path / "my.csv"
     my_csv.write_text("val\n2\n3\n1")


### PR DESCRIPTION
As previously, we use the repository to separate the display of the number from the computation of the number. As we don't (yet) need to generalise the computation of the number, we make
`get_num_logged_in_users` a method rather than a function.

Closes #173