### PR TITLE
Rewrite `justfile` to improve the development setup

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,6 @@ Next, run the following commands:
 
 ```sh
 just devenv
-source .env
 just run python -m tasks list # lists all tasks
 just run python -m tasks run <task> # runs individual tasks
 just run streamlit run app/app.py

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set dotenv-load := true
+
 PYTHON := "python3.12"
 VENV_DIR := ".venv"
 BIN_DIR := VENV_DIR / "bin"


### PR DESCRIPTION
Closes #152.

Lean on the `just` commands for the development setup, so that we do not have to fiddle with activated virtual environments or manually export environment variables when running tasks / the app. 