### PR TITLE
Set up Dependabot to update github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
The file added is identical to the one in our repo template; it sets up dependabot to check for github action updates monthly, with a 7-day cooldown that matches our dependency updates policy.

Closes #154.
